### PR TITLE
Abstract out the API Gateway instructions to remove github-specific references

### DIFF
--- a/irc_hooky/github/github_webhook.py
+++ b/irc_hooky/github/github_webhook.py
@@ -8,7 +8,7 @@ class GithubWebhook(Webhook):
         super(GithubWebhook, self).__init__(event, context)
 
     def process_event(self):
-        payload = self.event.get('gh-payload')
+        payload = self.event.get('payload')
         if not payload:
             self.log.error("Received an empty github payload")
             return

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ def handle_github_hook(payload, headers):
     event = {
         "X-Hub-Signature": headers.get("X-Hub-Signature"),
         "X-Github-Event": headers.get("X-Github-Event"),
-        "gh-payload": payload
+        "payload": payload
     }
     gh_handler(event, {})
 

--- a/tests/github/test_github_webhook_issues.py
+++ b/tests/github/test_github_webhook_issues.py
@@ -7,7 +7,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
     def test_empty_payload(self):
         payload = {}
         event = {
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -19,7 +19,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
             "foo": "bar"
         }
         event = {
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -34,7 +34,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -54,7 +54,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -77,7 +77,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -105,7 +105,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -136,7 +136,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")
@@ -168,7 +168,7 @@ class TestGithubWebhookIssues(unittest.TestCase):
         }
         event = {
             "X-Github-Event": "issues",
-            "gh-payload": payload
+            "payload": payload
         }
         gh = GithubWebhook(event, {})
         self.assertEqual(gh.irc_message, "")


### PR DESCRIPTION
Theoretically these instructions should hold true for any new endpoint, regardless of type.
