### PR TITLE
Send IRC notifications using the python irc library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ lambda: env
 	rm -rf build
 	mkdir build
 	$(ENV)/bin/pip install -r requirements.txt -t build
+	$(ENV)/bin/pip install --upgrade setuptools -t build
+	$(ENV)/bin/pip install --upgrade distribute -t build
 	cp -R irc_hooky build/
 	chmod -R a+r build/*
 	find . -name "*.pyc" -exec /bin/rm -rf {} \;

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ test: install
 server:
 	$(ENV)/bin/python server.py 127.0.0.1 8080
 
+.PHONY: ngrok
+ngrok:
+	ngrok http 127.0.0.1:8080
+
 .PHONY: lambda
 lambda: env
 	rm -rf build

--- a/docs/api_gateway.rst
+++ b/docs/api_gateway.rst
@@ -116,6 +116,9 @@ something like:
         "X-Hub-Signature": $input.params().header.get("X-Hub-Signature"),
         "X-Github-Event": $input.params().header.get("X-Github-Event"),
         "resource-path": $context.resourcePath,
+        "irc-server": ${stageVariables.irc_server},
+        "irc-port": ${stageVariables.irc_port},
+        "irc-channel": ${stageVariables.irc_channel},
         "payload": $input.json("$")
     }
 
@@ -136,7 +139,7 @@ template above needs to be converted and supplied into the
         --type "AWS" \
         --uri "arn:aws:apigateway:${AWS_DEFAULT_REGION}:lambda:path/2015-03-31/functions/${LAMBDA_FUNCTION_ARN}/invocations" \
         --request-templates '{
-            "application/json": "{ \"X-Hub-Signature\": \"$input.params().header.get(\"X-Hub-Signature\")\", \"X-Github-Event\": \"$input.params().header.get(\"X-Github-Event\")\", \"resource-path\": \"$context.resourcePath\", \"payload\": $input.json(\"$\") }"
+            "application/json": "{ \"X-Hub-Signature\": \"$input.params().header.get(\"X-Hub-Signature\")\", \"X-Github-Event\": \"$input.params().header.get(\"X-Github-Event\")\", \"resource-path\": \"$context.resourcePath\", \"irc-server\": \"${stageVariables.irc_server}\", \"irc-port\": \"${stageVariables.irc_port}\", \"irc-channel\": \"${stageVariables.irc_channel}\", \"payload\": $input.json(\"$\") }"
         }'
 
 With that in place, the next thing we need to do here is to create a 200 method
@@ -198,7 +201,12 @@ __ http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html
     aws apigateway create-deployment \
         --region "$AWS_DEFAULT_REGION" \
         --rest-api-id "$REST_API_ID" \
-        --stage-name "prod"
+        --stage-name "prod" \
+        --variables '{
+            "irc_server": "chat.freenode.net",
+            "irc_port": "6667",
+            "irc_channel": "##testtest"
+        }'
 
 And that should be it! Your new Lambda-backed API should be available at:
 

--- a/irc_hooky/base_object.py
+++ b/irc_hooky/base_object.py
@@ -7,7 +7,7 @@ class BaseObject(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, **kwargs):
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger("irchooky")
         for prop in self.properties:
             setattr(self, prop, kwargs.get(prop, ""))
 

--- a/irc_hooky/entrypoint.py
+++ b/irc_hooky/entrypoint.py
@@ -1,17 +1,35 @@
 import logging
 from irc_hooky.github.github_webhook import GithubWebhook
+from irc_hooky.irc_client import IRCClient
 
 logging.basicConfig()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("irchooky")
 logger.setLevel(logging.INFO)
 
 
 def handler(event, context):
     resource_path = event.get('resource-path')
     if resource_path == "/github":
-        logger.debug("Received a request on the /github endpoint")
-        gh = GithubWebhook(event, context)
-        gh.process_event()
-        irc_msg = gh.get_irc_message()
-        logger.info(irc_msg)
-    return '{"success": true}'
+        handle_github_event(event, context)
+    return "{success: true}"
+
+
+def handle_github_event(event, context):
+    logger.debug("Received a request on the /github endpoint")
+    gh = GithubWebhook(event, context)
+    gh.process_event()
+    irc_msg = gh.irc_message
+    logger.info(irc_msg)
+    send_irc_msg(server=event.get('irc-server'),
+                 port=event.get('irc-port'),
+                 nickname=event.get('irc-nickname'),
+                 channel=event.get('irc-channel'),
+                 message=irc_msg)
+
+
+def send_irc_msg(server, port, nickname, channel, message):
+    irc_client = IRCClient(server, port, nickname)
+    if not irc_client.connect():
+        logger.error("Error connecting to IRC network")
+        return
+    irc_client.send_msg(message, channel)

--- a/irc_hooky/entrypoint.py
+++ b/irc_hooky/entrypoint.py
@@ -23,7 +23,7 @@ def handle_github_event(event, context):
     irc_msg = gh.irc_message
     logger.info(irc_msg)
     send_irc_msg(server=event.get('irc-server'),
-                 port=event.get('irc-port'),
+                 port=int(event.get('irc-port')),
                  nickname=event.get('irc-nickname'),
                  channel=event.get('irc-channel'),
                  message=irc_msg)

--- a/irc_hooky/entrypoint.py
+++ b/irc_hooky/entrypoint.py
@@ -1,7 +1,9 @@
 import logging
 from irc_hooky.github.github_webhook import GithubWebhook
 from irc_hooky.irc_client import IRCClient
+import json
 
+__version__ = "0.0.1"
 logging.basicConfig()
 logger = logging.getLogger("irchooky")
 logger.setLevel(logging.INFO)
@@ -11,7 +13,7 @@ def handler(event, context):
     resource_path = event.get('resource-path')
     if resource_path == "/github":
         handle_github_event(event, context)
-    return "{success: true}"
+    return json.dumps({"version": __version__})
 
 
 def handle_github_event(event, context):

--- a/irc_hooky/irc_client.py
+++ b/irc_hooky/irc_client.py
@@ -1,0 +1,71 @@
+import logging
+import irc.client
+
+
+class IRCClient(object):
+
+    def __init__(self, network, port, nickname):
+        self.log = logging.getLogger("irchooky")
+        self.network = network
+        self.port = port
+        self.nickname = nickname
+        self.server = None
+        self.client = None
+        self.channel = ""
+        self.message = ""
+        self.has_quit = False
+        if not self.nickname:
+            self.nickname = "irchooky"
+
+    def connect(self):  # pragma: no cover
+        self.client = irc.client.Reactor()
+        self.log.info("Connecting to IRC network %s" % self.network)
+        try:
+            self.server = self.client.server()
+            self.server.connect(self.network,
+                                self.port,
+                                self.nickname)
+            return True
+        except irc.client.ServerConnectionError as x:
+            self.log.error(x)
+            return False
+
+    def send_msg(self, msg, channel):
+        if not msg:
+            self.log.error("Invalid message")
+            return
+        self.message = msg
+
+        if not channel:
+            self.log.error("Invalid channel name")
+            return
+        self.channel = channel
+
+        self.server.add_global_handler("join", self.irc_on_join)
+        self.server.add_global_handler("welcome", self.irc_on_connect)
+        self.server.add_global_handler("passwdmismatch",
+                                       self.irc_on_passwdmismatch)
+        self.server.add_global_handler("disconnect", self.irc_on_disconnect)
+        self.main_loop()
+
+    def main_loop(self):  # pragma: no cover
+        while not self.has_quit:
+            self.client.process_once(0.2)
+
+    def irc_on_join(self, connection, event):  # pragma: no cover
+        self.log.info("Joined IRC channel %s" % self.channel)
+        self.log.info("Sending IRC message %s" % self.message)
+        connection.privmsg(self.channel, self.message)
+        connection.quit()
+
+    def irc_on_passwdmismatch(self, connection, event):  # pragma: no cover
+        self.log.error("Password required")
+        self.has_quit = True
+
+    def irc_on_connect(self, connection, event):  # pragma: no cover
+        self.log.info("Connected to IRC network.")
+        connection.join(self.channel)
+
+    def irc_on_disconnect(self, connection, event):  # pragma: no cover
+        self.log.info("Disconnecting from IRC network.")
+        self.has_quit = True

--- a/irc_hooky/webhook.py
+++ b/irc_hooky/webhook.py
@@ -7,7 +7,7 @@ class Webhook(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, event, context):
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger("irchooky")
         self.event = event
         self.context = context
         self.irc_message = ""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,12 +8,15 @@ bumpversion==0.5.3
 coverage==4.0.3
 docutils==0.12
 flake8==2.5.1
+funcsigs==0.4
 futures==3.0.4
 Jinja2==2.8
 jmespath==0.9.0
 MarkupSafe==0.23
 mccabe==0.3.1
+mock==1.3.0
 nose==1.3.7
+pbr==1.8.1
 pep8==1.7.0
 pyflakes==1.0.0
 Pygments==2.1

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ def handle_github_hook(payload, headers):
         "irc-channel": "##testtest",
         "payload": payload
     }
-    handler(event, {})
+    return handler(event, {})
 
 
 class LocalIRCHooky(BaseHTTPServer.BaseHTTPRequestHandler):
@@ -29,15 +29,18 @@ class LocalIRCHooky(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.end_headers()
+        self.wfile.write("Nothing to see here!")
 
     def do_POST(self):
         length = int(self.headers['Content-Length'])
         post_data = self.rfile.read(length)
         payload = json.loads(post_data)
         if (self.path == "/github"):
-            handle_github_hook(payload, self.headers)
+            result = handle_github_hook(payload, self.headers)
         self.send_response(200)
+        self.send_header("Content-type", "application/json")
         self.end_headers()
+        self.wfile.write(result)
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@ import BaseHTTPServer
 import sys
 import time
 import json
-from irc_hooky.github.main import handler as gh_handler
+from irc_hooky.entrypoint import handler
 
 
 HOST_NAME = sys.argv[1]
@@ -13,9 +13,13 @@ def handle_github_hook(payload, headers):
     event = {
         "X-Hub-Signature": headers.get("X-Hub-Signature"),
         "X-Github-Event": headers.get("X-Github-Event"),
+        "resource-path": "/github",
+        "irc-server": "chat.freenode.net",
+        "irc-port": 6667,
+        "irc-channel": "##testtest",
         "payload": payload
     }
-    gh_handler(event, {})
+    handler(event, {})
 
 
 class LocalIRCHooky(BaseHTTPServer.BaseHTTPRequestHandler):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ current_version = 0.0.1
 commit = True
 tag = True
 message = Update IRC Hooky from {current_version} to {new_version}
+
+[bumpversion:file:docs/conf.py]
+
+[bumpversion:file:irc_hooky/entrypoint.py]

--- a/tests/test_irc_client.py
+++ b/tests/test_irc_client.py
@@ -1,0 +1,38 @@
+import unittest
+from mock import MagicMock
+from mock import call
+from irc_hooky.irc_client import IRCClient
+
+
+class TestIRCClient(unittest.TestCase):
+
+    def setUp(self):
+        self.client = IRCClient("foo.bar.net",
+                                1234,
+                                "nickname")
+        self.client.main_loop = MagicMock()
+        self.client.server = MagicMock()
+
+    def test_nicknames(self):
+        self.assertEqual(self.client.nickname, "nickname")
+        self.client = IRCClient("foo.bar.net", 1234, "")
+        self.assertEqual(self.client.nickname, "irchooky")
+
+    def test_send_empty_msg(self):
+        self.client.send_msg("", "#channel")
+        self.assertEqual(self.client.main_loop.mock_calls,
+                         [])
+        self.assertEqual(self.client.server.mock_calls,
+                         [])
+
+    def test_send_empty_channel(self):
+        self.client.send_msg("message", "")
+        self.assertEqual(self.client.main_loop.mock_calls,
+                         [])
+        self.assertEqual(self.client.server.mock_calls,
+                         [])
+
+    def test_send_msg(self):
+        self.client.send_msg("message", "#channel")
+        self.assertEqual(self.client.main_loop.mock_calls, [call()])
+        self.assertEqual(len(self.client.server.mock_calls), 4)


### PR DESCRIPTION
One of the interesting problems here is that API Gateway requests are restricted to 10 seconds. The problem with this is that IRC connection operations take _a while_ (timed it at ~13 seconds).

http://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html

I am going to attempt to trigger an asynchronous operation so that the lambda function can return back to the caller in under 10 seconds.
