### PR TITLE
Send the IRC message using an asynchronous version of the IRC Hooky Lambda function

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,5 +36,6 @@ this out!
 
    faq
    lambda
+   sns
    api_gateway
    lambda_update

--- a/docs/lambda.rst
+++ b/docs/lambda.rst
@@ -41,9 +41,14 @@ First, the policy for our Lambda role:
               "Action": [
                 "logs:CreateLogGroup",
                 "logs:CreateLogStream",
-                "logs:PutLogEvents"
+                "logs:PutLogEvents",
+                "sns:Publish",
+                "sns:Subscribe"
               ],
-              "Resource": "arn:aws:logs:*:*:*"
+              "Resource": [
+                "arn:aws:logs:*:*:*",
+                "arn:aws:sns:*"
+                ]
             }
           ]
         }'
@@ -103,7 +108,7 @@ release.
 
 __ https://github.com/marvinpinto/irc-hooky/releases/latest
 
-Create the Lambda function in a 128MB container and a 10-second timeout.
+Create the Lambda function in a 128MB container and a 60-second timeout.
 
 .. code-block:: bash
 
@@ -112,7 +117,7 @@ Create the Lambda function in a 128MB container and a 10-second timeout.
         --runtime "python2.7" \
         --role "$LAMBDA_BASIC_ROLE_ARN" \
         --handler "irc_hooky/entrypoint.handler" \
-        --timeout 10 \
+        --timeout 60 \
         --memory-size 128 \
         --publish \
         --zip-file "fileb://lambda.zip"

--- a/docs/lambda.rst
+++ b/docs/lambda.rst
@@ -101,7 +101,7 @@ Before creating the Lambda function, head on over to `IRC Hooky Releases`__
 page and download the the ``lambda.zip`` that corresponds to the most recent
 release.
 
-__ https://github.com/marvinpinto/irc-hooky/releases
+__ https://github.com/marvinpinto/irc-hooky/releases/latest
 
 Create the Lambda function in a 128MB container and a 10-second timeout.
 

--- a/docs/lambda_update.rst
+++ b/docs/lambda_update.rst
@@ -27,5 +27,5 @@ Finally update and deploy the new version of the Lambda function!
         --publish \
         --zip-file "fileb://lambda.zip"
 
-__ https://github.com/marvinpinto/irc-hooky/releases
+__ https://github.com/marvinpinto/irc-hooky/releases/latest
 __ https://aws.amazon.com/cli

--- a/docs/sns.rst
+++ b/docs/sns.rst
@@ -1,0 +1,43 @@
+SNS Topic Setup
+===============
+
+Let's get started with a bit of prep-work. Set the following environment
+variables which we'll use for all the subsequent steps.
+
+.. code-block:: bash
+
+    export AWS_ACCESS_KEY_ID=<YOUR AWS ACCESS KEY>
+    export AWS_SECRET_ACCESS_KEY=<YOUR AWS SECRET KEY>
+    export AWS_DEFAULT_REGION=us-east-1
+    LAMBDA_FUNCTION_ARN="<YOUR LAMBDA FUNCTION ARN>"
+
+Note that if you don't have the ARN for your Lambda function handy, you should
+be able to find it using the following:
+
+.. code-block:: bash
+
+    aws lambda list-functions
+
+Create a new SNS topic called ``irc-hooky``. We'll use this topic as the
+trigger for the asynchronous invocations.
+
+.. code-block:: bash
+
+    aws sns create-topic \
+        --name "irc-hooky"
+
+Take note of the ``TopicArn`` value from the above command's output and export
+it as an environment variable.
+
+.. code-block:: bash
+
+    SNS_TOPIC_ARN="arn:aws:sns..."
+
+Now subscribe the Lambda function you created to this SNS topic:
+
+.. code-block:: bash
+
+    aws sns subscribe \
+        --topic-arn "$SNS_TOPIC_ARN" \
+        --protocol lambda \
+        --notification-endpoint "$LAMBDA_FUNCTION_ARN"

--- a/irc_hooky/entrypoint.py
+++ b/irc_hooky/entrypoint.py
@@ -2,6 +2,7 @@ import logging
 from irc_hooky.github.github_webhook import GithubWebhook
 from irc_hooky.irc_client import IRCClient
 import json
+import boto3
 
 __version__ = "0.0.2"
 logging.basicConfig()
@@ -10,10 +11,27 @@ logger.setLevel(logging.INFO)
 
 
 def handler(event, context):
+    json_version = json.dumps({"version": __version__})
+    logger.debug("Received event: %s" % event)
+
+    if is_sns_event(event):
+        send_irc_msg(event, context)
+        return json_version
+
     resource_path = event.get('resource-path')
     if resource_path == "/github":
         handle_github_event(event, context)
-    return json.dumps({"version": __version__})
+
+    return json_version
+
+
+def is_sns_event(event):
+    """
+    Determine if the event we just received is an SNS event
+    """
+    if "Records" in event:
+        return True
+    return False
 
 
 def handle_github_event(event, context):
@@ -22,16 +40,40 @@ def handle_github_event(event, context):
     gh.process_event()
     irc_msg = gh.irc_message
     logger.info(irc_msg)
-    send_irc_msg(server=event.get('irc-server'),
-                 port=int(event.get('irc-port')),
-                 nickname=event.get('irc-nickname'),
-                 channel=event.get('irc-channel'),
-                 message=irc_msg)
+    event.update({'irc-message': irc_msg})
+    send_sns_msg(event, context)
 
 
-def send_irc_msg(server, port, nickname, channel, message):
-    irc_client = IRCClient(server, port, nickname)
-    if not irc_client.connect():
-        logger.error("Error connecting to IRC network")
-        return
-    irc_client.send_msg(message, channel)
+def send_sns_msg(event, context):
+    message = {
+        "irc-server": event.get('irc-server'),
+        "irc-port": event.get('irc-port'),
+        "irc-channel": event.get('irc-channel'),
+        "irc-nickname": event.get('irc-nickname'),
+        "irc-message": event.get('irc-message')
+    }
+    logger.info("Will publish message to SNS: %s" % json.dumps(message))
+    client = boto3.client('sns')
+    response = client.publish(TopicArn=event.get('irchooky-sns-arn'),
+                              Message=json.dumps(message))
+    logger.info("SNS publish result: %s" % response)
+
+
+def send_irc_msg(event, context):
+    logger.debug("Received an SNS event: %s" % json.dumps(event))
+
+    # This is going to hurt if there are more than one irc messages needing to
+    # be delivered, in the same SNS payload. Something to optimize for perhaps
+    # later.
+
+    for record in event['Records']:
+        msg_str = record['Sns'].get('Message')
+        msg_json = json.loads(msg_str)
+        logger.debug("Record: %s" % msg_json)
+
+        irc_client = IRCClient(network=msg_json.get('irc-server'),
+                               port=msg_json.get('irc-port'),
+                               nickname=msg_json.get('irc-nickname'))
+        irc_client.connect()
+        irc_client.send_msg(msg=msg_json.get('irc-message'),
+                            channel=msg_json.get('irc-channel'))

--- a/irc_hooky/irc_client.py
+++ b/irc_hooky/irc_client.py
@@ -7,7 +7,7 @@ class IRCClient(object):
     def __init__(self, network, port, nickname):
         self.log = logging.getLogger("irchooky")
         self.network = network
-        self.port = port
+        self.port = int(port)
         self.nickname = nickname
         self.server = None
         self.client = None
@@ -25,20 +25,17 @@ class IRCClient(object):
             self.server.connect(self.network,
                                 self.port,
                                 self.nickname)
-            return True
         except irc.client.ServerConnectionError as x:
             self.log.error(x)
-            return False
+            raise
 
     def send_msg(self, msg, channel):
         if not msg:
-            self.log.error("Invalid message")
-            return
+            raise Exception("Invalid message")
         self.message = msg
 
         if not channel:
-            self.log.error("Invalid channel name")
-            return
+            raise Exception("Invalid channel name")
         self.channel = channel
 
         self.server.add_global_handler("join", self.irc_on_join)
@@ -59,7 +56,7 @@ class IRCClient(object):
         connection.quit()
 
     def irc_on_passwdmismatch(self, connection, event):  # pragma: no cover
-        self.log.error("Password required")
+        raise Exception("IRC password required")
         self.has_quit = True
 
     def irc_on_connect(self, connection, event):  # pragma: no cover

--- a/tests/test_irc_client.py
+++ b/tests/test_irc_client.py
@@ -19,18 +19,12 @@ class TestIRCClient(unittest.TestCase):
         self.assertEqual(self.client.nickname, "irchooky")
 
     def test_send_empty_msg(self):
-        self.client.send_msg("", "#channel")
-        self.assertEqual(self.client.main_loop.mock_calls,
-                         [])
-        self.assertEqual(self.client.server.mock_calls,
-                         [])
+        with self.assertRaises(Exception):
+            self.client.send_msg("", "#channel")
 
     def test_send_empty_channel(self):
-        self.client.send_msg("message", "")
-        self.assertEqual(self.client.main_loop.mock_calls,
-                         [])
-        self.assertEqual(self.client.server.mock_calls,
-                         [])
+        with self.assertRaises(Exception):
+            self.client.send_msg("message", "")
 
     def test_send_msg(self):
         self.client.send_msg("message", "#channel")


### PR DESCRIPTION
The way this works is that the synchronous version of this function (the one that is triggered through API Gateway) publishes an SNS message with the details related to sending an IRC message.

The asynchronous version of the Lambda function (the one that is triggered via the SNS message) then takes the details and sends the IRC message.

The reasoning for this is that there is (currently) a hard 10-second limit on requests triggered via API Gateway and unfortunately sending IRC messages takes longer than that.

See this PR for more details: https://github.com/marvinpinto/irc-hooky/pull/8
