### PR TITLE
Run the 'docs' target before the 'checkstyle' and 'test' targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ install:
   - ./env/bin/pip install coveralls
 
 script:
-  - make checkstyle
-  - make test
   - 'make docs'
+  - 'make checkstyle'
+  - 'make test'
 
 after_success:
   - ./env/bin/coveralls


### PR DESCRIPTION
The 'docs' target ends up deleting the `.coverage` file, which resulted in coveralls.io being very unhappy with this repository.
