### PR TITLE
Fix for the empty payload bug

### DIFF
--- a/irc_hooky/atlas/atlas_webhook.py
+++ b/irc_hooky/atlas/atlas_webhook.py
@@ -12,6 +12,7 @@ class AtlasWebhook(Webhook):
         payload = self.event.get('payload')
         if not payload:
             self.log.error("Received an empty atlas payload")
+            self.log.error(self.event)
             return
 
         event_type = self.get_atlas_event_type(payload)

--- a/irc_hooky/github/github_webhook.py
+++ b/irc_hooky/github/github_webhook.py
@@ -12,6 +12,7 @@ class GithubWebhook(Webhook):
         payload = self.event.get('payload')
         if not payload:
             self.log.error("Received an empty github payload")
+            self.log.error(self.event)
             return
 
         event_type = self.event.get('X-Github-Event')

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -239,16 +239,15 @@ class DeployIRCHooky(object):
 
     def api_gateway_input_mapping_tamplate(self):
         client = boto3.client('apigateway')
-        request_template = {
-            "X-Hub-Signature": "$input.params().header.get('X-Hub-Signature')",
-            "X-Github-Event": "$input.params().header.get('X-Github-Event')",
-            "resource-path": "$context.resourcePath",
-            "irc-server": "${stageVariables.irc_server}",
-            "irc-port": "${stageVariables.irc_port}",
-            "irc-channel": "${stageVariables.irc_channel}",
-            "irchooky-sns-arn": "${stageVariables.irchooky_sns_arn}",
-            "payload": "$input"
-        }
+        t = []
+        t.append("{\"X-Hub-Signature\": \"$input.params().header.get('X-Hub-Signature')\"")  # NOQA
+        t.append("\"X-Github-Event\": \"$input.params().header.get('X-Github-Event')\"")  # NOQA
+        t.append("\"resource-path\": \"$context.resourcePath\"")
+        t.append("\"irc-server\": \"${stageVariables.irc_server}\"")
+        t.append("\"irc-port\": \"${stageVariables.irc_port}\"")
+        t.append("\"irc-channel\": \"${stageVariables.irc_channel}\"")
+        t.append("\"irchooky-sns-arn\": \"${stageVariables.irchooky_sns_arn}\"")  # NOQA
+        t.append("\"payload\": $input.json('$')}")
         uri = "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (self.region, self.lambda_function_arn)  # NOQA
         client.put_integration(
             restApiId=self.rest_api_id,
@@ -257,7 +256,7 @@ class DeployIRCHooky(object):
             integrationHttpMethod="POST",
             uri=uri,
             type="AWS",
-            requestTemplates={"application/json": json.dumps(request_template)}
+            requestTemplates={"application/json": ",".join(t)}
         )
         self.log.info("Input request mapping template complete")
 


### PR DESCRIPTION
Ran into a situation where API Gateway would seemingly send an empty payload into the Lambda function.

After shaving many AWS yaks (figuring out IAM roles, enabling logging on all the things, etc) I tracked it down to the API Gateway Mapping template.

Looking at the docs here:

http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#input-variable-reference

You will notice that one of the examples is:

```
{
  "name" : "$input.params('name')",
  "body" : $input.json('$')
}
```

You will also notice that that is _not_ valid JSON. This was the clue for me.

I had assumed all along that the mapping template had to be valid json, which was why using a function like `json.dumps` works and makes sense!

In the end, it turns out that what I needed for the payload value was indeed `$input.json('$')`, and this is why you will notice that handcrafted artisanal "json like" mapping template.
