### PR TITLE
Add a 5-second delay before creating lambda function

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -5,6 +5,7 @@ import boto3
 import botocore.exceptions
 import json
 import requests
+import time
 
 logging.basicConfig()
 logging.captureWarnings(True)
@@ -351,6 +352,8 @@ if __name__ == "__main__":
     dpl.create_lambda_policy()
     dpl.create_lambda_role()
     dpl.attach_lambda_role_policy()
+    time.sleep(5)                     # Wait for role policy to take effect before creating lambda function,
+                                      # see https://stackoverflow.com/a/37438525/305559
     dpl.create_lambda_function()
     dpl.wire_sns_notifications()
     dpl.sns_lambda_permission()

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -352,8 +352,11 @@ if __name__ == "__main__":
     dpl.create_lambda_policy()
     dpl.create_lambda_role()
     dpl.attach_lambda_role_policy()
-    time.sleep(5)                     # Wait for role policy to take effect before creating lambda function,
-                                      # see https://stackoverflow.com/a/37438525/305559
+
+    # Wait for role policy to take effect before creating lambda function,
+    # see https://stackoverflow.com/a/37438525/305559
+    time.sleep(5)
+
     dpl.create_lambda_function()
     dpl.wire_sns_notifications()
     dpl.sns_lambda_permission()


### PR DESCRIPTION
There seems to be a race condition where creating a lambda function immediately after creating the role policy can fail with an error complaining that the role does not allow the action.  Closes #22 .